### PR TITLE
fix(nextclade): move placementMaskRanges to tree.json, remove obsolete fields

### DIFF
--- a/chikV/dataset/pathogen.json
+++ b/chikV/dataset/pathogen.json
@@ -2,25 +2,14 @@
   "attributes": {
     "name": "chikV",
     "reference accession": "NC_004162.2",
-    "reference name": "S27-African"
+    "reference name": "S27-African",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "placementMaskRanges": [
-    {
-      "begin": 0,
-      "end": 77
-    },
-    {
-      "begin": 11314,
-      "end": 11826
-    }
-  ],
   "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/chikV/resources/auspice_config.json
+++ b/chikV/resources/auspice_config.json
@@ -64,5 +64,19 @@
     "map",
     "entropy",
     "frequencies"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "placement_mask_ranges": [
+        {
+          "begin": 0,
+          "end": 77
+        },
+        {
+          "begin": 11314,
+          "end": 11826
+        }
+      ]
+    }
+  }
 }

--- a/chikV/resources/chikV/pathogen.json
+++ b/chikV/resources/chikV/pathogen.json
@@ -2,25 +2,14 @@
   "attributes": {
     "name": "chikV",
     "reference accession": "NC_004162.2",
-    "reference name": "S27-African"
+    "reference name": "S27-African",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "placementMaskRanges": [
-    {
-      "begin": 0,
-      "end": 77
-    },
-    {
-      "begin": 11314,
-      "end": 11826
-    }
-  ],
   "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/denv/resources/denv1/auspice_config.json
+++ b/denv/resources/denv1/auspice_config.json
@@ -68,5 +68,19 @@
     "map",
     "entropy",
     "frequencies"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "placement_mask_ranges": [
+        {
+          "begin": 0,
+          "end": 94
+        },
+        {
+          "begin": 10271,
+          "end": 10735
+        }
+      ]
+    }
+  }
 }

--- a/denv/resources/denv1/pathogen.json
+++ b/denv/resources/denv1/pathogen.json
@@ -2,19 +2,14 @@
   "attributes": {
     "name": "DENV-1",
     "reference accession": "NC_001477.1",
-    "reference name": "Nauru/NMRI-45AZ5PDK-0/1974"
+    "reference name": "Nauru/NMRI-45AZ5PDK-0/1974",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "placementMaskRanges":[
-    {"begin":0, "end":94},
-    {"begin":10271, "end":10735}
-  ],
   "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/denv/resources/denv2/auspice_config.json
+++ b/denv/resources/denv2/auspice_config.json
@@ -63,5 +63,19 @@
     "map",
     "entropy",
     "frequencies"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "placement_mask_ranges": [
+        {
+          "begin": 0,
+          "end": 94
+        },
+        {
+          "begin": 10271,
+          "end": 10735
+        }
+      ]
+    }
+  }
 }

--- a/denv/resources/denv2/pathogen.json
+++ b/denv/resources/denv2/pathogen.json
@@ -2,19 +2,14 @@
   "attributes": {
     "name": "DENV-2",
     "reference accession": "NC_001474.2",
-    "reference name": "Thailand/CDC-16681/1964"
+    "reference name": "Thailand/CDC-16681/1964",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "placementMaskRanges":[
-    {"begin":0, "end":94},
-    {"begin":10271, "end":10735}
-  ],
   "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/denv/resources/denv3/auspice_config.json
+++ b/denv/resources/denv3/auspice_config.json
@@ -63,5 +63,19 @@
     "map",
     "entropy",
     "frequencies"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "placement_mask_ranges": [
+        {
+          "begin": 0,
+          "end": 94
+        },
+        {
+          "begin": 10268,
+          "end": 10707
+        }
+      ]
+    }
+  }
 }

--- a/denv/resources/denv3/pathogen.json
+++ b/denv/resources/denv3/pathogen.json
@@ -2,19 +2,14 @@
   "attributes": {
     "name": "DENV-3",
     "reference accession": "NC_001475.2",
-    "reference name": "D3/H/IMTSSA-SRI/2000"
+    "reference name": "D3/H/IMTSSA-SRI/2000",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "placementMaskRanges":[
-    {"begin":0, "end":94},
-    {"begin":10268, "end":10707}
-  ],
   "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/denv/resources/denv4/auspice_config.json
+++ b/denv/resources/denv4/auspice_config.json
@@ -63,5 +63,19 @@
     "map",
     "entropy",
     "frequencies"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "placement_mask_ranges": [
+        {
+          "begin": 0,
+          "end": 101
+        },
+        {
+          "begin": 10266,
+          "end": 10649
+        }
+      ]
+    }
+  }
 }

--- a/denv/resources/denv4/pathogen.json
+++ b/denv/resources/denv4/pathogen.json
@@ -2,19 +2,14 @@
   "attributes": {
     "name": "DENV-4",
     "reference accession": "NC_002640.1",
-    "reference name": "rDEN4"
+    "reference name": "rDEN4",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "placementMaskRanges":[
-    {"begin":0, "end":101},
-    {"begin":10266, "end":10649}
-  ],
   "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",


### PR DESCRIPTION
Fix Nextclade dataset configuration issues in chikV and dengue pathogen.json and auspice_config.json files.

**placementMaskRanges:** The placement mask ranges for UTR regions were in pathogen.json at root level, where Nextclade does not read them. Moved to auspice_config.json under `extensions.nextclade.placement_mask_ranges`, so `augur export v2` embeds them into tree.json at `.meta.extensions.nextclade.placement_mask_ranges` where Nextclade reads them. Without this fix, placement masking was not applied.

**Obsolete fields:** Removed `enabled` and `experimental` from root level of pathogen.json. These are not recognized by the Nextclade pathogen.json schema and were silently ignored. Moved `experimental: true` to `attributes` where the dataset index reads it.

Affected datasets: chikV/genotypes, dengue/denv1, dengue/denv2, dengue/denv3, dengue/denv4

- [x] Move `placementMaskRanges` from pathogen.json to auspice_config.json `extensions.nextclade` (5 datasets)
- [x] Remove obsolete root-level fields (`enabled`, `experimental`) from pathogen.json (6 files incl. diverged chikV/dataset copy)
- [x] Move `experimental: true` to `attributes` (6 files)

> :warning: The existing datasets in `nextclade_data` are already patched in nextstrain/nextclade_data#418, so no immediate resubmission is needed. But without this upstream fix, the issues will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) and [auspice extensions schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/nextclade-auspice-extensions.schema.json) (`placement_mask_ranges` definition) for the expected field locations.

1. Related to: nextstrain/nextclade_data#418